### PR TITLE
Add ASF's related links to the iggy website

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -91,6 +91,20 @@ const config: Config = {
           label: 'GitHub',
           position: 'right',
         },
+        {
+            type: 'dropdown',
+            label: 'ASF',
+            position: 'right',
+            items: [
+              {label: 'Foundation', to: 'https://www.apache.org/'},
+              {label: 'License', to: 'https://www.apache.org/licenses/'},
+              {label: 'Events', to: 'https://www.apache.org/events/current-event.html'},
+              {label: 'Security', to: 'https://www.apache.org/security/'},
+              {label: 'Sponsorship', to: 'https://www.apache.org/foundation/sponsorship.html'},
+              {label: 'Privacy', to: 'https://privacy.apache.org/policies/privacy-policy-public.html'},
+              {label: 'Thanks', to: 'https://www.apache.org/foundation/thanks.html'}
+            ],
+        },
       ],
     },
     footer: {


### PR DESCRIPTION
The ASF requires including the following links in the website, see https://www.apache.org/foundation/marks/pmcs#navigation

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/47af2214-3c83-40cb-b501-0708bbbc81c7" />
