### PR TITLE
chore: Forward notifications for github-generated events to commits@iggy.a.o

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,6 @@ publish:
 
 notifications:
   commits: commits@iggy.apache.org
-  issues: dev@iggy.apache.org
-  pullrequests: dev@iggy.apache.org
+  issues: commits@iggy.apache.org
+  pullrequests: commits@iggy.apache.org
   discussions: dev@iggy.apache.org


### PR DESCRIPTION
This PR aims to forward notifications for gitHub-generated events to commits@iggy.a.o so that developers subscribed to the list won't be overwhelmed, as they already receive their own GitHub notifications.