### PR TITLE
Redirect issues/pullrequest notification to commits@iggy.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,6 @@ publish:
 
 notifications:
   commits: commits@iggy.apache.org
-  issues: dev@iggy.apache.org
-  pullrequests: dev@iggy.apache.org
+  issues: commits@iggy.apache.org
+  pullrequests: commits@iggy.apache.org
   discussions: dev@iggy.apache.org


### PR DESCRIPTION
It might flood the dev@iggy.apache.org if send the issues/pullrequests noitfication to the dev channel. And it's unnecessary since we can find them on GitHub.