### PR TITLE
Fix broken iggy references

### DIFF
--- a/blog/2023-08-19-message-headers.md
+++ b/blog/2023-08-19-message-headers.md
@@ -26,7 +26,7 @@ Since the headers are optional, you can send a message without any headers at al
 
 For now, there are no reserved headers, so you can use any key you want. However, in the future, we might introduce some reserved headers used by the streaming server for the specific purposes such as the message compression, distributed tracing and so no.
 
-The **sample applications** using the message headers can be found [here](https://github.com/apache/iggy/tree/master/examples/src/message-headers).
+The **sample applications** using the message headers can be found [here](https://github.com/apache/iggy/tree/master/core/examples/src/message-headers).
 
 ## Implementation
 

--- a/blog/2023-08-22-message-state.md
+++ b/blog/2023-08-22-message-state.md
@@ -20,7 +20,7 @@ Starting with the commit [#b07f23d](https://github.com/apache/iggy/commit/b07f23
 
 ## Introduction
 
-The `state` is an additional field added to the `message` struct stored on the server-side, as well as polled by the client, which describes the current state of the message. By default, the message state is set to `available` (`code = 1``, see the possible codes below), meaning that the message is availabe to be consumed by the client.
+The `state` is an additional field added to the `message` struct stored on the server-side, as well as polled by the client, which describes the current state of the message. By default, the message state is set to `available` (`code = 1``, see the possible codes below), meaning that the message is available to be consumed by the client.
 
 However, the state might have a different value, for example `marked_for_deletion` (to be used by the upcoming retention policy feature), `poisoned` (to be used by the upcoming dead-letter queue feature) etc. In the future releases, the server will also provide a way to change the state of the message (for example to mark it as `poisoned` by the client), as well as filtering the messages by the state.
 

--- a/blog/2023-12-29-building-message-streaming-in-rust.md
+++ b/blog/2023-12-29-building-message-streaming-in-rust.md
@@ -50,7 +50,7 @@ let polled_messages = client.poll_messages(&PollMessages {
 }).await?;
 ```
 
-After running some benchmarks (yes, we have a dedicated app for the **[benchmarking purposes](https://github.com/apache/iggy/tree/master/bench)**) and seeing the promising numbers (**range of 2-6 GB/s for both, writes & reads when processing millions of messages**), I eventually decided to give it a long-term shot. Being fully aware that there's still lots to be done (speaking of many months, or even years), I couldn't be more happy to find out that there's also someone else out there, who would like to contribute to the project and become a part of the team.
+After running some benchmarks (yes, we have a dedicated app for the **[benchmarking purposes](https://github.com/apache/iggy/tree/master/core/bench)**) and seeing the promising numbers (**range of 2-6 GB/s for both, writes & reads when processing millions of messages**), I eventually decided to give it a long-term shot. Being fully aware that there's still lots to be done (speaking of many months, or even years), I couldn't be more happy to find out that there's also someone else out there, who would like to contribute to the project and become a part of the team.
 
 ![image](/building-message-streaming/iggy_bench.jpeg)
 
@@ -133,7 +133,7 @@ After gaining some traction a few months ago (mostly due to landing on the GitHu
 
 ![image](/building-message-streaming/gh_trending.jpeg)
 
-Considering what's already there, being worked on or planned for the future releases, such as interactive CLI, modern Web UI, optional data compression and archivization, plugin support or multiple SDKs, there are at least three additonal challenges to overcome:
+Considering what's already there, being worked on or planned for the future releases, such as interactive CLI, modern Web UI, optional data compression and archivization, plugin support or multiple SDKs, there are at least three additional challenges to overcome:
 
 **Clustering** - the possibility of having a **highly available and fault tolerant** distributed message streaming platform in a production environment, is typically one of the most important aspects when considering the particular tool. While it wouldn't be too difficult to implement the extension (think of a simple proxy/load balancer), allowing to monitor and deliver the data either to the primary or secondary replica (treated as a fallback server) and switch between them when one of the nodes goes down, such a solution would still result in SPOF and wouldn't really scale. Instead, we've started experimenting with [Raft](https://raft.github.io/) consensus mechanism (de facto the industry standard) in a dedicated [repository](https://github.com/iggy-rs/iggy-cluster-sandbox), which should allow us in delivering the truly fault tolerant, distributed infrastructure with an additional data replication at the partition level (so-called unit of parallelization).
 

--- a/blog/2024-05-29-one-year-of-building-the-message-streaming.md
+++ b/blog/2024-05-29-one-year-of-building-the-message-streaming.md
@@ -59,7 +59,7 @@ And at the same time, we've been experimenting a lot with some fancy stuff, whic
 
 The core message streaming server and multiple SDKs might sound as the most important parts of the whole ecosystem, but let's not forget about the **management tools**. How to quickly connect to the the server, create new topics, validate if the messages are being sent correctly, change the user permissions or check the node statistics?
 
-This is where our **[CLI](https://github.com/apache/iggy/tree/master/cli) and [Web UI](https://github.com/iggy-rs/iggy-web-ui) come in handy**. If you're a fan of working with the terminal and used to the great developer experience, you'll find our CLI a joy to work with.
+This is where our **[CLI](https://github.com/apache/iggy/tree/master/core/cli) and [Web UI](https://github.com/iggy-rs/iggy-web-ui) come in handy**. If you're a fan of working with the terminal and used to the great developer experience, you'll find our CLI a joy to work with.
 
 ![image](/one-year-of-building-the-message-streaming/iggy_cli.png)
 
@@ -67,7 +67,7 @@ On the other hand, if you prefer a graphical interface accessible via your brows
 
 ![image](/one-year-of-building-the-message-streaming/iggy_web.png)
 
-Last but not least, in order to run the benchmarks, we have our own [bench](https://github.com/apache/iggy/tree/master/bench) available as a part of the core repository — you can easily configure the number of producers, consumers, streams, etc. and get an overview of the possible streaming performance on your machine.
+Last but not least, in order to run the benchmarks, we have our own [bench](https://github.com/apache/iggy/tree/master/core/bench) available as a part of the core repository — you can easily configure the number of producers, consumers, streams, etc. and get an overview of the possible streaming performance on your machine.
 
 ![image](/one-year-of-building-the-message-streaming/iggy_bench.png)
 

--- a/docs/introduction/getting_started.md
+++ b/docs/introduction/getting_started.md
@@ -11,7 +11,7 @@ Once you're familiar with the [architecture](/docs/introduction/architecture), i
 
 In the typical scenario, e.g. when working with the microservices architecture or any other kind of the distributed system, each application can be both at the same time (producer and consumer), as the particular service might publish its own messages (typically in a form of the events - facts, that have already happened) while at the same time be interested in the notifications coming from the other service(s).
 
-The completed sample can be found in [repository](https://github.com/apache/iggy/tree/master/examples/src/getting-started), however, we will go through the implementation step by step, so that you can get a better understanding of how to build the applications from scratch.
+The completed sample can be found in [repository](https://github.com/apache/iggy/tree/master/core/examples/src/getting-started), however, we will go through the implementation step by step, so that you can get a better understanding of how to build the applications from scratch.
 
 Also, please do keep in mind that we'll be using the default implementation of `IggyClient` which provides a wrapper on top of the low-level, transport-specific `Client` trait (which you can always use, if you want to have more control over the communication with the server).
 
@@ -93,7 +93,7 @@ client.connect().await?;
 
 The default server address being `127.0.0.1:8090` is configured on the server side, and can be easily adjusted by updating the `server.toml` (the default configuration) or `server.json` file in `configs` directory.
 
-We could make use of more advanced components such as [`ClientProvider`](https://github.com/apache/iggy/blob/master/sdk/src/client_provider.rs), pass the custom configuration built via console args to choose between the different protocols as all the available clients implement the same [Client](https://github.com/apache/iggy/blob/master/sdk/src/client.rs) trait and so on.
+We could make use of more advanced components such as [`ClientProvider`](https://github.com/apache/iggy/blob/master/core/sdk/src/client_provider.rs), pass the custom configuration built via console args to choose between the different protocols as all the available clients implement the same [Client](https://github.com/apache/iggy/blob/master/core/sdk/src/clients/client.rs) trait and so on.
 
 If you're eager to find out how to build more advanced (and configurable) applications, check the Rust [examples](/docs/sdk/rust/examples). Nevertheless, let's focus on implementing our producer side :)
 
@@ -133,7 +133,7 @@ From that point on, when starting the application, you should be able to see at 
 
 So far, so good, however, before we will be able to publish any messages to our streaming server, at first, we need to create the stream, topic and partition(s) - if you're unfamiliar with these concepts, please refer to [architecture](/docs/introduction/architecture) where all these concepts are described in-depth.
 
-Since our `IggyClient` implements the common [Client](https://github.com/apache/iggy/blob/master/sdk/src/client.rs) trait, you can find lots of the different methods to interact with the server, also from the administrative point of view, e.g. creating the streams, topics etc.
+Since our `IggyClient` implements the common [Client](https://github.com/apache/iggy/blob/master/core/sdk/src/clients/client.rs) trait, you can find lots of the different methods to interact with the server, also from the administrative point of view, e.g. creating the streams, topics etc.
 
 One thing worth mentioning is that, these methods are not idempotent - for example, if you were to try creating the stream with the same ID which already exists on the server, you would receive the specific error. In such a case, you can simply check for an error and move on. Let's do this then :)
 
@@ -192,7 +192,7 @@ async fn init_system(client: &IggyClient) {
 
 Finally, let's send some messages into our stream. We will implement the basic loop with an interval between each iteration to simulate publishing the batch of messages. Since the streaming server works directly with the binary data, and couldn't care less about the (de)serialization format for the message payload, it's really up to you, how to efficiently stream the messages for your use case.
 
-In our example, we will simply use the string payload, and pass it via `from_str` trait to construct the [Message](https://github.com/apache/iggy/blob/master/sdk/src/messages/send_messages.rs#L423).
+In our example, we will simply use the string payload, and pass it via `from_str` trait to construct the [Message](https://github.com/apache/iggy/blob/master/core/common/src/commands/messages/send_messages.rs#L423).
 
 ```rust
 let payload = "hello world";
@@ -537,4 +537,4 @@ Start the Iggy server, and then producer and consumer applications respectively 
 
 ## Summary
 
-What we've just achieved is merely the tip of an iceberg, however, it should give you a good understanding of what Iggy is all about, and hopefully, it wasn't too difficult to follow and get things up and running for the first time. Feel free to take a look at the more advanced [examples](https://github.com/apache/iggy/tree/master/examples), how to make use of `IggyClient` wrapper on top of the existing implementations of the `Client` trait, what happens when you start multiple producers and consumers and so on. Happy tweaking! :)
+What we've just achieved is merely the tip of an iceberg, however, it should give you a good understanding of what Iggy is all about, and hopefully, it wasn't too difficult to follow and get things up and running for the first time. Feel free to take a look at the more advanced [examples](https://github.com/apache/iggy/tree/master/core/examples), how to make use of `IggyClient` wrapper on top of the existing implementations of the `Client` trait, what happens when you start multiple producers and consumers and so on. Happy tweaking! :)

--- a/docs/introduction/high_level_sdk.md
+++ b/docs/introduction/high_level_sdk.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 If you've read through the [getting started](/introduction/getting-started) guide, you might have noticed that it's quite verbose and requires a lot of boilerplate code to get started. This is where the High-level SDK comes in, as it does provide a more user-friendly interface to interact with the Iggy API for both, producer and consumer. Let's consider the following features:
 
 - Automatically creating & joining the consumer groups
-- Commiting the offset depending on the particular mode (e.g. in the background based on some interval, after polling N messages etc.)
+- Committing the offset depending on the particular mode (e.g. in the background based on some interval, after polling N messages etc.)
 - Batching the messages, whether it's about producing or consuming
 - Processing the messages as if the stream was an async iterator
 - Reusing the same client for both, producing and consuming on the same topic without repeating the configuration

--- a/docs/introduction/stream_builder.md
+++ b/docs/introduction/stream_builder.md
@@ -16,7 +16,7 @@ you typically encounter one or more of the following scenarios:
 5) Add producers dynamically at runtime.
 
 The stream builder provides a convenient way to create the iggy client, producer and consumer for these use cases.
-All source code examples are located in the [**examples folder**](https://github.com/apache/iggy/tree/master/examples/src/stream-builder) of the iggy repository. Also,
+All source code examples are located in the [**examples folder**](https://github.com/apache/iggy/tree/master/core/examples/src/stream-builder) of the iggy repository. Also,
 if you encounter a problem with any of the examples below, please ask in the [**community discord**](https://discord.gg/C5Sux5NcRa).
 
 ## IggyStream Builder
@@ -127,7 +127,7 @@ constructor with the following:
 ```
 
 You find sample utils to build a customized iggy client in
-the [**examples folder**](https://github.com/apache/iggy/blob/master/examples/src/shared/client.rs) of the iggy
+the [**examples folder**](https://github.com/apache/iggy/blob/master/core/examples/src/shared/client.rs) of the iggy
 repository.
 
 ### Producer configuration
@@ -217,7 +217,7 @@ async fn main() -> Result<(), IggyError> {
 ```
 
 Note, when your requirements exceed this configuration, you can still
-use the [**underlying low level SDK**](https://github.com/apache/iggy/blob/master/examples/src/basic/producer/main.rs) for fine grained control over every detail of the producer.
+use the [**underlying low level SDK**](https://github.com/apache/iggy/blob/master/core/examples/src/basic/producer/main.rs) for fine grained control over every detail of the producer.
 
 ## IggyStreamConsumer Builder
 
@@ -274,7 +274,7 @@ consumer. To do so, just replace the `with_client_from_url` with the following:
 ```
 
 Notice, you find some utils to build a customized iggy client in
-the [**examples folder**](https://github.com/apache/iggy/blob/master/examples/src/shared/client.rs) of the iggy
+the [**examples folder**](https://github.com/apache/iggy/blob/master/core/examples/src/shared/client.rs) of the iggy
 repository.
 
 ### Consumer configuration
@@ -308,7 +308,7 @@ async fn main() -> Result<(), IggyError> {
     .topic_id(topic.try_into()?)
     .topic_name(topic)
     // The auto-commit configuration for storing the message offset.
-    // See: https://github.com/apache/iggy/blob/master/sdk/src/clients/consumer.rs
+    // See: https://github.com/apache/iggy/blob/master/core/sdk/src/clients/consumer.rs
     .auto_commit(AutoCommit::When(AutoCommitWhen::PollingMessages))
     // The max number of messages to send in a batch.
     // The greater the batch size, the higher the bulk throughput.

--- a/docs/sdk/rust/examples.md
+++ b/docs/sdk/rust/examples.md
@@ -5,7 +5,7 @@ title: Examples
 sidebar_position: 2
 ---
 
-In the core repository, you can find the following [examples](https://github.com/apache/iggy/tree/master/examples/src) using the Rust SDK:
+In the core repository, you can find the following [examples](https://github.com/apache/iggy/tree/master/core/examples/src) using the Rust SDK:
 
 - **Getting started** - the basic example which is discussed in the [getting started](/introduction/getting-started) guide.
 - **Message envelope** - the example of how to send a message with a custom envelope e.g. to differentiate between different types of messages.

--- a/docs/server/benchmarking.md
+++ b/docs/server/benchmarking.md
@@ -11,7 +11,7 @@ We've also built the **[benchmarking platform](https://benchmarks.iggy.rs)** whe
 
 ![Benchmarking Platform](/img/bench_platform.png)
 
-Iggy comes with a built-in benchmarking tool `iggy-bench` that allows you to measure the performance of the server. It is written in Rust and uses the `tokio` runtime for asynchronous I/O operations mimicking the example client applications.  The tool is designed to be as close to real-world scenarios as possible, so you can use it to estimate the performance of the server in your environment. It is part of the [core repository](https://github.com/apache/iggy/tree/master/bench) and can be found in the `bench` directory.
+Iggy comes with a built-in benchmarking tool `iggy-bench` that allows you to measure the performance of the server. It is written in Rust and uses the `tokio` runtime for asynchronous I/O operations mimicking the example client applications.  The tool is designed to be as close to real-world scenarios as possible, so you can use it to estimate the performance of the server in your environment. It is part of the [core repository](https://github.com/apache/iggy/tree/master/core/bench) and can be found in the `bench` directory.
 
 ![Bench CLI](/img/bench_cli.png)
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -495,7 +495,7 @@ recreate_missing_state = true
 
 An optional transport layer, which can be used to connect to the server with any tool or application that supports HTTP. It is enabled by default, but you can disable it by setting `enabled` to `false`. The `address` option specifies the address and port to listen on. The `cors` section allows you to configure the CORS policy, which internally uses [Tower middleware](https://docs.rs/tower-http/latest/tower_http/cors/index.html).
 
-HTTP API is built on top of [Axum](https://github.com/tokio-rs/axum) and you can find all the available endpoints in [server.http](https://github.com/apache/iggy/blob/master/server/server.http) file, which can be used with [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for VS Code.
+HTTP API is built on top of [Axum](https://github.com/tokio-rs/axum) and you can find all the available endpoints in [server.http](https://github.com/apache/iggy/blob/master/core/server/server.http) file, which can be used with [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for VS Code.
 
 To consume the HTTP API from Iggy SDK, you need to make use of the available `HttpClient` component.
 

--- a/docs/server/introduction.md
+++ b/docs/server/introduction.md
@@ -13,7 +13,7 @@ The releases are published to GitHub and can be found [here](https://github.com/
 
 Keep in mind, that if you were to compile the source code in release mode, the longer compilation time is due to [LTO](https://doc.rust-lang.org/rustc/linker-plugin-lto.html) enabled in [profile](https://github.com/apache/iggy/blob/master/Cargo.toml#L2).
 
-The HTTP API endpoints can be found in [server.http](https://github.com/apache/iggy/blob/master/server/server.http) file, which can be used with [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for VS Code.
+The HTTP API endpoints can be found in [server.http](https://github.com/apache/iggy/blob/master/core/server/server.http) file, which can be used with [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for VS Code.
 
 In order to see the detailed logs from the server, run it with `RUST_LOG=trace` environment variable.
 

--- a/docs/server/schema.md
+++ b/docs/server/schema.md
@@ -9,7 +9,7 @@ Since the Iggy server supports a variety of transport protocols, it is important
 
 Currently, there are 2 ways of data representation: JSON (text) and binary - any serialization format that you prefer such as bincode, SBE, flatbuffers, protobuf or even your custom one, as the server simply expects the raw bytes as the message payload.
 
-The binary format is more compact and efficient, but it is not human-readable - it's being used by TCP and QUIC transports. The JSON format is used by HTTP transport - all the existing endpoints are available in the [server.http](https://github.com/apache/iggy/blob/master/server/server.http).
+The binary format is more compact and efficient, but it is not human-readable - it's being used by TCP and QUIC transports. The JSON format is used by HTTP transport - all the existing endpoints are available in the [server.http](https://github.com/apache/iggy/blob/master/core/server/server.http).
 
 ## Request schema
 


### PR DESCRIPTION
## PR Summary
The iggy commit https://github.com/apache/iggy/commit/eec28c5ef6fe63d41a8a466d80bae850457ec951 split the Rust SDK into smaller packages - Mainly moving them into `core`. This PR adjusts sources to changes.