### PR TITLE
fix(docs): correct Go SDK quickstart and examples to match the SDK API (closes #36)

### DIFF
--- a/content/docs/sdk/go/examples.mdx
+++ b/content/docs/sdk/go/examples.mdx
@@ -12,12 +12,15 @@ A complete getting-started example is available in the [examples/go](https://git
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/apache/iggy/foreign/go/client"
 	"github.com/apache/iggy/foreign/go/client/tcp"
 	iggcon "github.com/apache/iggy/foreign/go/contracts"
+	ierror "github.com/apache/iggy/foreign/go/errors"
 )
 
 var (
@@ -36,19 +39,26 @@ func main() {
 	}
 	defer cli.Close()
 
-	// Log in
-	if _, err := cli.LoginUser("iggy", "iggy"); err != nil {
+	ctx := context.Background()
+	if err := cli.Connect(ctx); err != nil {
 		panic(err)
 	}
 
-	// Create a stream
-	if _, err := cli.CreateStream("sample-stream"); err != nil {
+	// Log in
+	if _, err := cli.LoginUser(ctx, "iggy", "iggy"); err != nil {
+		panic(err)
+	}
+
+	// Create a stream. Re-running this example is fine: an existing stream is not an error.
+	if _, err := cli.CreateStream(ctx, "sample-stream"); err != nil &&
+		!errors.Is(err, ierror.ErrStreamNameAlreadyExists) {
 		panic(err)
 	}
 
 	// Create a topic with 1 partition, no compression, no expiry
 	streamIdentifier, _ := iggcon.NewIdentifier(StreamId)
 	if _, err := cli.CreateTopic(
+		ctx,
 		streamIdentifier,
 		"sample-topic",
 		1,                                  // partitions count
@@ -56,7 +66,7 @@ func main() {
 		iggcon.IggyExpiryNeverExpire,
 		0,                                  // max topic size
 		nil,                                // replication factor
-	); err != nil {
+	); err != nil && !errors.Is(err, ierror.ErrTopicNameAlreadyExists) {
 		panic(err)
 	}
 
@@ -69,6 +79,7 @@ func main() {
 		streamIdentifier, _ := iggcon.NewIdentifier(StreamId)
 		topicIdentifier, _ := iggcon.NewIdentifier(TopicId)
 		if err := cli.SendMessages(
+			ctx,
 			streamIdentifier,
 			topicIdentifier,
 			partitioning,
@@ -76,6 +87,7 @@ func main() {
 		); err != nil {
 			panic(err)
 		}
+		fmt.Printf("Sent: %s\n", payload)
 		time.Sleep(500 * time.Millisecond)
 	}
 }
@@ -87,6 +99,7 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -111,8 +124,13 @@ func main() {
 	}
 	defer cli.Close()
 
+	ctx := context.Background()
+	if err := cli.Connect(ctx); err != nil {
+		panic(err)
+	}
+
 	// Log in
-	if _, err := cli.LoginUser("iggy", "iggy"); err != nil {
+	if _, err := cli.LoginUser(ctx, "iggy", "iggy"); err != nil {
 		panic(err)
 	}
 
@@ -124,6 +142,7 @@ func main() {
 		streamIdentifier, _ := iggcon.NewIdentifier(StreamID)
 		topicIdentifier, _ := iggcon.NewIdentifier(TopicID)
 		pollMessages, err := cli.PollMessages(
+			ctx,
 			streamIdentifier,
 			topicIdentifier,
 			consumer,

--- a/content/docs/sdk/go/intro.mdx
+++ b/content/docs/sdk/go/intro.mdx
@@ -16,43 +16,83 @@ go get github.com/apache/iggy/foreign/go
 package main
 
 import (
-    "fmt"
-    "log"
-    iggy "github.com/apache/iggy/foreign/go"
+	"context"
+	"errors"
+	"log"
+
+	"github.com/apache/iggy/foreign/go/client"
+	"github.com/apache/iggy/foreign/go/client/tcp"
+	iggcon "github.com/apache/iggy/foreign/go/contracts"
+	ierror "github.com/apache/iggy/foreign/go/errors"
 )
 
 func main() {
-    client, err := iggy.NewClient("localhost:8090")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer client.Close()
+	cli, err := client.NewIggyClient(
+		client.WithTcp(tcp.WithServerAddress("127.0.0.1:8090")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := cli.Close(); err != nil {
+			log.Printf("Error closing client: %v", err)
+		}
+	}()
 
-    err = client.Login("iggy", "iggy")
-    if err != nil {
-        log.Fatal(err)
-    }
+	ctx := context.Background()
+	if err := cli.Connect(ctx); err != nil {
+		log.Fatal(err)
+	}
 
-    // Create a stream
-    err = client.CreateStream("my-stream")
-    if err != nil {
-        log.Fatal(err)
-    }
+	if _, err := cli.LoginUser(ctx, "iggy", "iggy"); err != nil {
+		log.Fatal(err)
+	}
 
-    // Create a topic with 2 partitions
-    err = client.CreateTopic("my-stream", "my-topic", 2)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Re-running this example is fine: an existing stream or topic is not an error.
+	if _, err := cli.CreateStream(ctx, "sample-stream"); err != nil &&
+		!errors.Is(err, ierror.ErrStreamNameAlreadyExists) {
+		log.Fatal(err)
+	}
 
-    // Send a message
-    err = client.SendMessages("my-stream", "my-topic", 1,
-        [][]byte{[]byte("Hello from Go!")})
-    if err != nil {
-        log.Fatal(err)
-    }
+	streamId, err := iggcon.NewIdentifier("sample-stream")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    fmt.Println("Message sent successfully")
+	if _, err := cli.CreateTopic(
+		ctx,
+		streamId,
+		"sample-topic",
+		1,
+		iggcon.CompressionAlgorithmNone,
+		iggcon.IggyExpiryNeverExpire,
+		0,
+		nil,
+	); err != nil && !errors.Is(err, ierror.ErrTopicNameAlreadyExists) {
+		log.Fatal(err)
+	}
+
+	topicId, err := iggcon.NewIdentifier("sample-topic")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	message, err := iggcon.NewIggyMessage([]byte("Hello from Go!"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := cli.SendMessages(
+		ctx,
+		streamId,
+		topicId,
+		iggcon.None(),
+		[]iggcon.IggyMessage{message},
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Message sent")
 }
 ```
 


### PR DESCRIPTION
`intro.mdx` imported `github.com/apache/iggy/foreign/go`, a module path with no
package at its root, then used `iggy.NewClient`, `Login`, a three-argument
`CreateTopic`, and `SendMessages` taking `[][]byte`. None of those exist.

`examples.mdx` had the right imports and constructor but omitted the context
argument on every call and never called `Connect`.

All three snippets now run against `apache/iggy:edge`: the quickstart sends a
message, the producer sends ten, the consumer reads them back. They are safe to
re-run, ignoring only "already exists" on stream and topic creation via
`errors.Is`, and the producer logs each send so the user can see what is going on.

AI was used to help make this fix. Reviewed and fully tested by a human.