### PR TITLE
fix(docs): make Python SDK quickstart and examples runnable (closes #48)

### DIFF
--- a/content/docs/sdk/python/examples.mdx
+++ b/content/docs/sdk/python/examples.mdx
@@ -11,6 +11,7 @@ Working examples are available in the [examples/python](https://github.com/apach
 
 ```python
 import asyncio
+
 from apache_iggy import IggyClient
 from apache_iggy import SendMessage as Message
 
@@ -18,23 +19,26 @@ STREAM_NAME = "sample-stream"
 TOPIC_NAME = "sample-topic"
 PARTITION_ID = 0
 
+
 async def main():
     client = IggyClient.from_connection_string(
         "iggy+tcp://iggy:iggy@127.0.0.1:8090"
     )
     await client.connect()
 
-    await client.create_stream(name=STREAM_NAME)
-    await client.create_topic(
-        stream=STREAM_NAME,
-        partitions_count=1,
-        name=TOPIC_NAME,
-        replication_factor=1,
-    )
+    # Re-running this example is fine: only create what is missing.
+    if await client.get_stream(STREAM_NAME) is None:
+        await client.create_stream(name=STREAM_NAME)
 
-    messages = []
-    for i in range(10):
-        messages.append(Message(f"message-{i}"))
+    if await client.get_topic(STREAM_NAME, TOPIC_NAME) is None:
+        await client.create_topic(
+            stream=STREAM_NAME,
+            name=TOPIC_NAME,
+            partitions_count=1,
+            replication_factor=1,
+        )
+
+    messages = [Message(f"message-{i}") for i in range(10)]
 
     await client.send_messages(
         stream=STREAM_NAME,
@@ -42,6 +46,8 @@ async def main():
         partitioning=PARTITION_ID,
         messages=messages,
     )
+    print(f"Sent {len(messages)} message(s)")
+
 
 asyncio.run(main())
 ```
@@ -50,11 +56,13 @@ asyncio.run(main())
 
 ```python
 import asyncio
-from apache_iggy import IggyClient, PollingStrategy, ReceiveMessage
+
+from apache_iggy import IggyClient, PollingStrategy
 
 STREAM_NAME = "sample-stream"
 TOPIC_NAME = "sample-topic"
 PARTITION_ID = 0
+
 
 async def main():
     client = IggyClient.from_connection_string(
@@ -62,6 +70,8 @@ async def main():
     )
     await client.connect()
 
+    # Next() with auto_commit=True continues from this consumer's last committed
+    # offset, so each run picks up where the previous one finished.
     polled_messages = await client.poll_messages(
         stream=STREAM_NAME,
         topic=TOPIC_NAME,
@@ -74,6 +84,7 @@ async def main():
     for message in polled_messages:
         payload = message.payload().decode("utf-8")
         print(f"Offset: {message.offset()}, Payload: {payload}")
+
 
 asyncio.run(main())
 ```

--- a/content/docs/sdk/python/intro.mdx
+++ b/content/docs/sdk/python/intro.mdx
@@ -15,6 +15,8 @@ pip install apache-iggy
 ### Producer
 
 ```python
+import asyncio
+
 from apache_iggy import IggyClient
 from apache_iggy import SendMessage as Message
 
@@ -22,56 +24,74 @@ STREAM_NAME = "sample-stream"
 TOPIC_NAME = "sample-topic"
 PARTITION_ID = 0
 
-client = IggyClient.from_connection_string("iggy+tcp://iggy:iggy@localhost:8090")
-await client.connect()
 
-await client.create_stream(name=STREAM_NAME)
-await client.create_topic(
-    stream=STREAM_NAME,
-    name=TOPIC_NAME,
-    partitions_count=1,
-    replication_factor=1,
-)
+async def main():
+    client = IggyClient.from_connection_string(
+        "iggy+tcp://iggy:iggy@127.0.0.1:8090"
+    )
+    await client.connect()
 
-messages = []
-for i in range(10):
-    payload = f"message-{i}"
-    message = Message(payload)
-    messages.append(message)
+    # Re-running this example is fine: only create what is missing.
+    if await client.get_stream(STREAM_NAME) is None:
+        await client.create_stream(name=STREAM_NAME)
 
-await client.send_messages(
-    stream=STREAM_NAME,
-    topic=TOPIC_NAME,
-    partitioning=PARTITION_ID,
-    messages=messages,
-)
+    if await client.get_topic(STREAM_NAME, TOPIC_NAME) is None:
+        await client.create_topic(
+            stream=STREAM_NAME,
+            name=TOPIC_NAME,
+            partitions_count=1,
+            replication_factor=1,
+        )
+
+    messages = [Message(f"message-{i}") for i in range(10)]
+
+    await client.send_messages(
+        stream=STREAM_NAME,
+        topic=TOPIC_NAME,
+        partitioning=PARTITION_ID,
+        messages=messages,
+    )
+    print(f"Sent {len(messages)} message(s)")
+
+
+asyncio.run(main())
 ```
 
 ### Consumer
 
 ```python
-from apache_iggy import IggyClient, PollingStrategy, ReceiveMessage
+import asyncio
+
+from apache_iggy import IggyClient, PollingStrategy
 
 STREAM_NAME = "sample-stream"
 TOPIC_NAME = "sample-topic"
 PARTITION_ID = 0
 
-client = IggyClient.from_connection_string("iggy+tcp://iggy:iggy@localhost:8090")
-await client.connect()
 
-polled_messages = await client.poll_messages(
-    stream=STREAM_NAME,
-    topic=TOPIC_NAME,
-    partition_id=PARTITION_ID,
-    polling_strategy=PollingStrategy.Next(),
-    count=10,
-    auto_commit=True,
-)
+async def main():
+    client = IggyClient.from_connection_string(
+        "iggy+tcp://iggy:iggy@127.0.0.1:8090"
+    )
+    await client.connect()
 
-if polled_messages:
+    # Next() with auto_commit=True continues from this consumer's last committed
+    # offset, so each run picks up where the previous one finished.
+    polled_messages = await client.poll_messages(
+        stream=STREAM_NAME,
+        topic=TOPIC_NAME,
+        partition_id=PARTITION_ID,
+        polling_strategy=PollingStrategy.Next(),
+        count=10,
+        auto_commit=True,
+    )
+
     for message in polled_messages:
         payload = message.payload().decode("utf-8")
         print(f"Offset: {message.offset()}, Payload: {payload}")
+
+
+asyncio.run(main())
 ```
 
 ## Examples


### PR DESCRIPTION
The Python snippets on both SDK doc pages could not run. `intro.mdx` used
`await` at module level, which is a syntax error in a script.

Changes to both pages:

- wrapped in `async def main()` with `asyncio.run(main())`
- `127.0.0.1` rather than `localhost`, since the server listens on IPv4 only by
  default
- create the stream and topic only when `get_stream` / `get_topic` return None,
  so re-runs are clean
- dropped the unused `ReceiveMessage` import
- the producer now prints what it sent, rather than succeeding in silence
- noted that `Next()` with `auto_commit=True` continues from the last committed
  offset, so consecutive runs read successive batches

Run against `apache/iggy:edge` producer twice, then the consumer twice, with the second
consumer run picking up the next ten as expected.

AI was used to help create this. Reviewed and tested by a real human.