### PR TITLE
fix(docs): make Node SDK quickstart and examples runnable (closes #51)

### DIFF
--- a/content/docs/sdk/node/examples.mdx
+++ b/content/docs/sdk/node/examples.mdx
@@ -18,20 +18,31 @@ Working examples are available in the [examples/node](https://github.com/apache/
 ```typescript
 import { Client, Partitioning } from 'apache-iggy';
 
+const STREAM_NAME = 'sample-stream';
+const TOPIC_NAME = 'sample-topic';
+
 const client = new Client({
   transport: 'TCP',
-  options: { port: 8090, host: '127.0.0.1', keepAlive: true },
+  options: { port: 8090, host: '127.0.0.1' },
   credentials: { username: 'iggy', password: 'iggy' },
 });
 
-const stream = await client.stream.create({ name: 'sample-stream' });
-const topic = await client.topic.create({
-  streamId: stream.id,
-  name: 'sample-topic',
-  partitionCount: 1,
-  compressionAlgorithm: 1,
-  replicationFactor: 1,
-});
+// Re-running this example is fine: only create what is missing.
+const streams = await client.stream.list();
+const stream =
+  streams.find((s) => s.name === STREAM_NAME) ??
+  (await client.stream.create({ name: STREAM_NAME }));
+
+const topics = await client.topic.list({ streamId: stream.id });
+const topic =
+  topics.find((t) => t.name === TOPIC_NAME) ??
+  (await client.topic.create({
+    streamId: stream.id,
+    name: TOPIC_NAME,
+    partitionCount: 1,
+    compressionAlgorithm: 1,
+    replicationFactor: 1,
+  }));
 
 const messages = Array.from({ length: 10 }, (_, i) => ({
   id: i + 1,
@@ -43,10 +54,10 @@ await client.message.send({
   streamId: stream.id,
   topicId: topic.id,
   messages,
-  partition: Partitioning.PartitionId(
-    topic.partitions[0].id
-  ),
+  partition: Partitioning.Balanced,
 });
+
+console.log(`Sent ${messages.length} message(s)`);
 
 await client.destroy();
 ```
@@ -56,8 +67,8 @@ await client.destroy();
 ```typescript
 import { Client, PollingStrategy, Consumer } from 'apache-iggy';
 
-const STREAM_ID = 1;
-const TOPIC_ID = 1;
+const STREAM_NAME = 'sample-stream';
+const TOPIC_NAME = 'sample-topic';
 const PARTITION_ID = 0;
 
 const client = new Client({
@@ -66,21 +77,21 @@ const client = new Client({
   credentials: { username: 'iggy', password: 'iggy' },
 });
 
+// Next with autocommit continues from this consumer's last committed offset,
+// so each run picks up where the previous one finished.
 const polledMessages = await client.message.poll({
-  streamId: STREAM_ID,
-  topicId: TOPIC_ID,
+  streamId: STREAM_NAME,
+  topicId: TOPIC_NAME,
   consumer: Consumer.Single,
   partitionId: PARTITION_ID,
-  pollingStrategy: PollingStrategy.Offset(BigInt(0)),
+  pollingStrategy: PollingStrategy.Next,
   count: 10,
-  autocommit: false,
+  autocommit: true,
 });
 
 for (const message of polledMessages.messages) {
   const payload = message.payload.toString('utf8');
-  console.log(
-    `Offset: ${message.headers.offset}, Payload: ${payload}`
-  );
+  console.log(`Offset: ${message.headers.offset}, Payload: ${payload}`);
 }
 
 await client.destroy();

--- a/content/docs/sdk/node/intro.mdx
+++ b/content/docs/sdk/node/intro.mdx
@@ -17,30 +17,48 @@ npm install apache-iggy
 ```typescript
 import { Client, Partitioning } from 'apache-iggy';
 
+const STREAM_NAME = 'sample-stream';
+const TOPIC_NAME = 'sample-topic';
+
 const client = new Client({
   transport: 'TCP',
-  options: {
-    port: 8090,
-    host: '127.0.0.1',
-  },
-  credentials: {
-    username: 'iggy',
-    password: 'iggy',
-  },
+  options: { port: 8090, host: '127.0.0.1' },
+  credentials: { username: 'iggy', password: 'iggy' },
 });
 
-const messages = Array.from({ length: 10 }).map((_, i) => ({
+// Re-running this example is fine: only create what is missing.
+const streams = await client.stream.list();
+const stream =
+  streams.find((s) => s.name === STREAM_NAME) ??
+  (await client.stream.create({ name: STREAM_NAME }));
+
+const topics = await client.topic.list({ streamId: stream.id });
+const topic =
+  topics.find((t) => t.name === TOPIC_NAME) ??
+  (await client.topic.create({
+    streamId: stream.id,
+    name: TOPIC_NAME,
+    partitionCount: 1,
+    compressionAlgorithm: 1,
+    replicationFactor: 1,
+  }));
+
+const messages = Array.from({ length: 10 }, (_, i) => ({
   id: i + 1,
   headers: [],
   payload: `message-${i + 1}`,
 }));
 
 await client.message.send({
-  streamId: 1,
-  topicId: 1,
+  streamId: stream.id,
+  topicId: topic.id,
   messages,
-  partition: Partitioning.PartitionId(1),
+  partition: Partitioning.Balanced,
 });
+
+console.log(`Sent ${messages.length} message(s)`);
+
+await client.destroy();
 ```
 
 ### Consumer
@@ -48,38 +66,34 @@ await client.message.send({
 ```typescript
 import { Client, PollingStrategy, Consumer } from 'apache-iggy';
 
+const STREAM_NAME = 'sample-stream';
+const TOPIC_NAME = 'sample-topic';
+const PARTITION_ID = 0;
+
 const client = new Client({
   transport: 'TCP',
-  options: {
-    port: 8090,
-    host: '127.0.0.1',
-  },
-  credentials: {
-    username: 'iggy',
-    password: 'iggy',
-  },
+  options: { port: 8090, host: '127.0.0.1' },
+  credentials: { username: 'iggy', password: 'iggy' },
 });
 
-const STREAM_ID = 1;
-const TOPIC_ID = 1;
-const PARTITION_ID = 1;
-
+// Next with autocommit continues from this consumer's last committed offset,
+// so each run picks up where the previous one finished.
 const polledMessages = await client.message.poll({
-  streamId: STREAM_ID,
-  topicId: TOPIC_ID,
+  streamId: STREAM_NAME,
+  topicId: TOPIC_NAME,
   consumer: Consumer.Single,
   partitionId: PARTITION_ID,
-  pollingStrategy: PollingStrategy.Offset(BigInt(0)),
+  pollingStrategy: PollingStrategy.Next,
   count: 10,
-  autocommit: false,
+  autocommit: true,
 });
 
-if (polledMessages && polledMessages.messages.length > 0) {
-  for (const message of polledMessages.messages) {
-    const payload = message.payload.toString('utf8');
-    console.log(`Offset: ${message.headers.offset}, Payload: ${payload}`);
-  }
+for (const message of polledMessages.messages) {
+  const payload = message.payload.toString('utf8');
+  console.log(`Offset: ${message.headers.offset}, Payload: ${payload}`);
 }
+
+await client.destroy();
 ```
 
 ## Examples


### PR DESCRIPTION
The Node quickstart sent to a stream and topic it never created, so it failed
immediately on a fresh server.

Both pages now:

- look up the stream and topic by name and create only what is missing, so runs
  are repeatable
- use `Partitioning.Balanced` instead of indexing `topic.partitions`, which is
  absent from the object `topic.list` returns even though `topic.create`
  includes it
- address the stream and topic by name in the consumer rather than assuming ids 1 and 1
- poll with `PollingStrategy.Next` and `autocommit: true`, so consecutive runs
  read successive batches instead of repeating the first ten
- fix `partitionId` from 1 to 0
- call `client.destroy()`

Verified against `apache/iggy:edge`: producer twice, consumer twice, second run
picking up the next batch.

AI was used to help draft this. Reviewed and tested by a real human.