### PR TITLE
fix(docs): make the Rust SDK quickstart compile and run (closes #54)

### DIFF
--- a/content/docs/sdk/rust/intro.mdx
+++ b/content/docs/sdk/rust/intro.mdx
@@ -63,43 +63,56 @@ iggy://iggypat-your-token@localhost:8090
 
 ```rust
 use iggy::prelude::*;
+use std::str::FromStr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = IggyClient::from_connection_string("iggy://iggy:iggy@localhost:8090")?;
+    let client = IggyClient::from_connection_string("iggy://iggy:iggy@127.0.0.1:8090")?;
     client.connect().await?;
 
-    // Create stream and topic
-    client.create_stream("my-stream").await?;
-    client.create_topic(
-        &"my-stream".try_into()?,
-        "my-topic",
-        2,
-        CompressionAlgorithm::None,
-        None,
-        IggyExpiry::NeverExpire,
-        MaxTopicSize::ServerDefault,
-    ).await?;
+    // Re-running this example is fine: an existing stream or topic is not an error.
+    match client.create_stream("my-stream").await {
+        Ok(_) | Err(IggyError::StreamNameAlreadyExists(_)) => {}
+        Err(e) => return Err(e.into()),
+    }
+    match client
+        .create_topic(
+            &"my-stream".try_into()?,
+            "my-topic",
+            1,
+            CompressionAlgorithm::None,
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+    {
+        Ok(_) | Err(IggyError::TopicNameAlreadyExists(_, _)) => {}
+        Err(e) => return Err(e.into()),
+    }
 
-    // Send a message
     let msg = IggyMessage::from_str("hello world")?;
-    client.send_messages(
-        &"my-stream".try_into()?,
-        &"my-topic".try_into()?,
-        &Partitioning::balanced(),
-        &mut [msg],
-    ).await?;
+    client
+        .send_messages(
+            &"my-stream".try_into()?,
+            &"my-topic".try_into()?,
+            &Partitioning::partition_id(0),
+            &mut [msg],
+        )
+        .await?;
+    println!("Message sent");
 
-    // Poll messages
-    let polled = client.poll_messages(
-        &"my-stream".try_into()?,
-        &"my-topic".try_into()?,
-        Some(1),
-        &Consumer::default(),
-        &PollingStrategy::offset(0),
-        10,
-        false,
-    ).await?;
+    let polled = client
+        .poll_messages(
+            &"my-stream".try_into()?,
+            &"my-topic".try_into()?,
+            Some(0),
+            &Consumer::default(),
+            &PollingStrategy::next(),
+            10,
+            true,
+        )
+        .await?;
 
     for message in &polled.messages {
         let payload = std::str::from_utf8(&message.payload)?;


### PR DESCRIPTION
- add the missing `use std::str::FromStr;`
- one partition instead of two, with send and poll both on partition 0
- `127.0.0.1` rather than `localhost`
- tolerate `StreamNameAlreadyExists` / `TopicNameAlreadyExists` so it re-runs
- `PollingStrategy::next()` with autocommit, so consecutive runs advance instead
  of returning the same message
- print on send

Verified against `apache/iggy:latest` with `iggy` 0.10 from crates.io.

AI was used to help draft this. Reviewed, modified and tested by a real human.