### PR TITLE
fix(docs): make Java SDK examples re-runnable and report the right offset (closes #56)

### DIFF
--- a/content/docs/sdk/java/examples.mdx
+++ b/content/docs/sdk/java/examples.mdx
@@ -27,28 +27,44 @@ import java.util.List;
 import static java.util.Optional.empty;
 
 public class Producer {
+
+    static final String STREAM_NAME = "sample-stream";
+    static final StreamId STREAM_ID = StreamId.of(STREAM_NAME);
+    static final String TOPIC_NAME = "sample-topic";
+    static final TopicId TOPIC_ID = TopicId.of(TOPIC_NAME);
+
     public static void main(String[] args) {
         try (var client = IggyTcpClient.builder()
-                .host("localhost")
+                .host("127.0.0.1")
                 .port(8090)
                 .credentials("iggy", "iggy")
                 .buildAndLogin()) {
 
-            var streamId = StreamId.of("sample-stream");
-            var topicId = TopicId.of("sample-topic");
+            // Re-running this example is fine: only create what is missing.
+            if (client.streams().getStream(STREAM_ID).isEmpty()) {
+                client.streams().createStream(STREAM_NAME);
+            }
+            if (client.topics().getTopic(STREAM_ID, TOPIC_ID).isEmpty()) {
+                client.topics().createTopic(
+                        STREAM_ID,
+                        1L,
+                        CompressionAlgorithm.None,
+                        BigInteger.ZERO,
+                        BigInteger.ZERO,
+                        empty(),
+                        TOPIC_NAME);
+            }
 
-            client.streams().createStream("sample-stream");
-            client.topics().createTopic(
-                    streamId, 1L,
-                    CompressionAlgorithm.None,
-                    BigInteger.ZERO, BigInteger.ZERO,
-                    empty(), "sample-topic");
-
-            var partitioning = Partitioning.partitionId(0L);
-            var messages = List.of(Message.of("hello world"));
-            client.messages().sendMessages(
-                    streamId, topicId,
-                    partitioning, messages);
+            Partitioning partitioning = Partitioning.partitionId(0L);
+            for (int i = 0; i < 10; i++) {
+                String payload = "message-" + i;
+                client.messages().sendMessages(
+                        STREAM_ID,
+                        TOPIC_ID,
+                        partitioning,
+                        List.of(Message.of(payload)));
+                System.out.println("Sent: " + payload);
+            }
         }
     }
 }
@@ -69,28 +85,38 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class ConsumerExample {
+
+    static final StreamId STREAM_ID = StreamId.of("sample-stream");
+    static final TopicId TOPIC_ID = TopicId.of("sample-topic");
+
     public static void main(String[] args) {
         try (var client = IggyTcpClient.builder()
-                .host("localhost")
+                .host("127.0.0.1")
                 .port(8090)
                 .credentials("iggy", "iggy")
                 .buildAndLogin()) {
 
-            var streamId = StreamId.of("sample-stream");
-            var topicId = TopicId.of("sample-topic");
-            var consumer = Consumer.of(0L);
+            BigInteger offset = BigInteger.ZERO;
+            Consumer consumer = Consumer.of(0L);
 
-            PolledMessages polled = client.messages()
-                    .pollMessages(
-                            streamId, topicId,
-                            Optional.of(0L), consumer,
-                            PollingStrategy.offset(BigInteger.ZERO),
-                            10L, false);
+            while (true) {
+                PolledMessages polledMessages = client.messages().pollMessages(
+                        STREAM_ID,
+                        TOPIC_ID,
+                        Optional.of(0L),
+                        consumer,
+                        PollingStrategy.offset(offset),
+                        10L,
+                        false);
 
-            for (Message message : polled.messages()) {
-                String payload = new String(
-                        message.payload(), StandardCharsets.UTF_8);
-                System.out.println("Payload: " + payload);
+                if (polledMessages.messages().isEmpty()) {
+                    break;
+                }
+                for (Message message : polledMessages.messages()) {
+                    String payload = new String(message.payload(), StandardCharsets.UTF_8);
+                    System.out.printf("Offset: %d, Payload: %s%n", message.header().offset(), payload);
+                }
+                offset = offset.add(BigInteger.valueOf(polledMessages.messages().size()));
             }
         }
     }

--- a/content/docs/sdk/java/intro.mdx
+++ b/content/docs/sdk/java/intro.mdx
@@ -34,7 +34,6 @@ import org.apache.iggy.message.Message;
 import org.apache.iggy.message.Partitioning;
 import org.apache.iggy.topic.CompressionAlgorithm;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 import static java.util.Optional.empty;
 
@@ -47,20 +46,25 @@ public class Producer {
 
     public static void main(String[] args) {
         try (var client = IggyTcpClient.builder()
-                .host("localhost")
+                .host("127.0.0.1")
                 .port(8090)
                 .credentials("iggy", "iggy")
                 .buildAndLogin()) {
 
-            client.streams().createStream(STREAM_NAME);
-            client.topics().createTopic(
-                    STREAM_ID,
-                    1L,
-                    CompressionAlgorithm.None,
-                    BigInteger.ZERO,
-                    BigInteger.ZERO,
-                    empty(),
-                    TOPIC_NAME);
+            // Re-running this example is fine: only create what is missing.
+            if (client.streams().getStream(STREAM_ID).isEmpty()) {
+                client.streams().createStream(STREAM_NAME);
+            }
+            if (client.topics().getTopic(STREAM_ID, TOPIC_ID).isEmpty()) {
+                client.topics().createTopic(
+                        STREAM_ID,
+                        1L,
+                        CompressionAlgorithm.None,
+                        BigInteger.ZERO,
+                        BigInteger.ZERO,
+                        empty(),
+                        TOPIC_NAME);
+            }
 
             Partitioning partitioning = Partitioning.partitionId(0L);
             for (int i = 0; i < 10; i++) {
@@ -70,6 +74,7 @@ public class Producer {
                         TOPIC_ID,
                         partitioning,
                         List.of(Message.of(payload)));
+                System.out.println("Sent: " + payload);
             }
         }
     }
@@ -97,7 +102,7 @@ public class SampleConsumer {
 
     public static void main(String[] args) {
         try (var client = IggyTcpClient.builder()
-                .host("localhost")
+                .host("127.0.0.1")
                 .port(8090)
                 .credentials("iggy", "iggy")
                 .buildAndLogin()) {
@@ -118,9 +123,9 @@ public class SampleConsumer {
                 if (polledMessages.messages().isEmpty()) {
                     break;
                 }
-                for (Message msg : polledMessages.messages()) {
-                    String payload = new String(msg.payload(), StandardCharsets.UTF_8);
-                    System.out.printf("Offset: %d, Payload: %s%n", offset, payload);
+                for (Message message : polledMessages.messages()) {
+                    String payload = new String(message.payload(), StandardCharsets.UTF_8);
+                    System.out.printf("Offset: %d, Payload: %s%n", message.header().offset(), payload);
                 }
                 offset = offset.add(BigInteger.valueOf(polledMessages.messages().size()));
             }

--- a/content/docs/sdk/rust/intro.mdx
+++ b/content/docs/sdk/rust/intro.mdx
@@ -63,43 +63,56 @@ iggy://iggypat-your-token@localhost:8090
 
 ```rust
 use iggy::prelude::*;
+use std::str::FromStr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = IggyClient::from_connection_string("iggy://iggy:iggy@localhost:8090")?;
+    let client = IggyClient::from_connection_string("iggy://iggy:iggy@127.0.0.1:8090")?;
     client.connect().await?;
 
-    // Create stream and topic
-    client.create_stream("my-stream").await?;
-    client.create_topic(
-        &"my-stream".try_into()?,
-        "my-topic",
-        2,
-        CompressionAlgorithm::None,
-        None,
-        IggyExpiry::NeverExpire,
-        MaxTopicSize::ServerDefault,
-    ).await?;
+    // Re-running this example is fine: an existing stream or topic is not an error.
+    match client.create_stream("my-stream").await {
+        Ok(_) | Err(IggyError::StreamNameAlreadyExists(_)) => {}
+        Err(e) => return Err(e.into()),
+    }
+    match client
+        .create_topic(
+            &"my-stream".try_into()?,
+            "my-topic",
+            1,
+            CompressionAlgorithm::None,
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+    {
+        Ok(_) | Err(IggyError::TopicNameAlreadyExists(_, _)) => {}
+        Err(e) => return Err(e.into()),
+    }
 
-    // Send a message
     let msg = IggyMessage::from_str("hello world")?;
-    client.send_messages(
-        &"my-stream".try_into()?,
-        &"my-topic".try_into()?,
-        &Partitioning::balanced(),
-        &mut [msg],
-    ).await?;
+    client
+        .send_messages(
+            &"my-stream".try_into()?,
+            &"my-topic".try_into()?,
+            &Partitioning::partition_id(0),
+            &mut [msg],
+        )
+        .await?;
+    println!("Message sent");
 
-    // Poll messages
-    let polled = client.poll_messages(
-        &"my-stream".try_into()?,
-        &"my-topic".try_into()?,
-        Some(1),
-        &Consumer::default(),
-        &PollingStrategy::offset(0),
-        10,
-        false,
-    ).await?;
+    let polled = client
+        .poll_messages(
+            &"my-stream".try_into()?,
+            &"my-topic".try_into()?,
+            Some(0),
+            &Consumer::default(),
+            &PollingStrategy::next(),
+            10,
+            true,
+        )
+        .await?;
 
     for message in &polled.messages {
         let payload = std::str::from_utf8(&message.payload)?;


### PR DESCRIPTION
- consumer prints `message.header().offset()` instead of the loop variable, so
  offsets are no longer all zero
- producer guards creation with `getStream` / `getTopic`, so it can be re-run
- `127.0.0.1` rather than `localhost`
- producer prints each send

Verified against `apache/iggy:latest`: producer twice with no exception, then the
consumer showing increasing offsets across all twenty messages.

AI was used to help draft this. Reviewed and tested by a real human.