### PR TITLE
fix(community): correct graduation checklist claims and invalid markup

### DIFF
--- a/src/app/(site)/community/become-a-committer/page.tsx
+++ b/src/app/(site)/community/become-a-committer/page.tsx
@@ -79,20 +79,20 @@ export default function BecomeACommitterPage() {
       <h2 className="mb-4 mt-12 text-2xl font-bold text-fd-foreground">
         Path to PMC Membership
       </h2>
-      <p className="max-w-3xl text-base leading-relaxed text-fd-muted-foreground">
+      <div className="max-w-3xl space-y-4 text-base leading-relaxed text-fd-muted-foreground">
         <p>
           The Project Management Committee (PMC or PPMC during incubation) is the official controlling body of the project. PMC members “must” be able to perform the official responsibilities of the PMC (verify releases and growth of committers/PMC). We “want” them to be people that have a vision for Iggy, technology and community wise.
-        </p><br/>
+        </p>
         <p>
           For the avoidance of doubt, not every PMC member needs to know all details of how exactly Iggy’s release process works (it is okay to understand the gist and how to find the details). Likewise, not every PMC member needs to be a visionary. We strive to build a PMC that covers all parts well, understanding that each member brings different strengths.
         </p>
-        <br />
         <p>
           Ideally, we find candidates among active community members that have shown initiative to shape the direction of Iggy (technology and community) and have shown willingness to learn the official processes, such as how to create or verify for releases.
         </p>
-        <br />
-        For more details on PMC roles and responsibilities, see <ExternalLink href="https://www.apache.org/foundation/how-it-works/#pmc">Apache PMC Guide</ExternalLink>.
-      </p>
+        <p>
+          For more details on PMC roles and responsibilities, see <ExternalLink href="https://www.apache.org/foundation/how-it-works/#pmc">Apache PMC Guide</ExternalLink>.
+        </p>
+      </div>
     </CommunityLayout>
   );
 }

--- a/src/app/(site)/community/graduation-checklist/page.tsx
+++ b/src/app/(site)/community/graduation-checklist/page.tsx
@@ -118,7 +118,7 @@ const checklist = [
         description:
           "Releases consist of source code distributed using standard archive formats.",
         status:
-          "YES. Source release is distributed via dist.apache.org and linked from Downloads page on iggy.apache.org website.",
+          "YES. Source releases are distributed via downloads.apache.org and linked from the Downloads page on iggy.apache.org.",
       },
       {
         id: "RE20",
@@ -139,7 +139,7 @@ const checklist = [
         description:
           "Convenience binaries are clearly distinguished from Apache releases.",
         status:
-          "YES. Users can easily build binaries from source code, and we do not provide binaries as Apache Releases.",
+          "YES. The source release is the official Apache release. Convenience binaries are published to Docker Hub, crates.io, npm, PyPI, Maven Central and NuGet, and are not ASF releases.",
       },
       {
         id: "RE50",
@@ -171,7 +171,7 @@ const checklist = [
         description:
           "The project provides a documented channel for reporting security issues.",
         status:
-          "YES. We encourage users to report issues on GitHub and Security page link provided under ASF menu on the website iggy.apache.org",
+          "YES. Security issues are reported privately to security@apache.org, as described at https://www.apache.org/security/ and linked from the website. Public channels such as GitHub issues must not be used for undisclosed vulnerabilities.",
       },
       {
         id: "QU40",


### PR DESCRIPTION
The graduation checklist stated that source releases are distributed via
dist.apache.org, that the project does not provide binaries, and that security
issues can be reported on GitHub.

- source releases are on downloads.apache.org; dist.apache.org is the staging
  area the distribution policy says not to link
- convenience binaries are published to Docker Hub, crates.io, npm, PyPI, Maven
  Central and NuGet, so the answer is that they exist and are not ASF releases
- undisclosed vulnerabilities go privately to security@apache.org, never to a
  public tracker

Also unnests a `<p>` containing three further `<p>` elements on the Become a
Committer page, which is invalid HTML and triggers React hydration warnings.